### PR TITLE
Remove unnecessary graylog security group rule

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -35,9 +35,8 @@ module "fargate_app" {
     environment = var.environment
     team        = var.team
   }
-  docker_image    = var.docker_image
-  graylog_cidr        = []
-  datadog_api_key = null
+  docker_image        = var.docker_image
+  datadog_api_key     = null
 }
 
 output "fargate_app_lb" {

--- a/nsg.tf
+++ b/nsg.tf
@@ -50,14 +50,3 @@ resource "aws_security_group_rule" "nsg_task_egress_rule" {
   security_group_id = aws_security_group.nsg_task.id
 }
 
-resource "aws_security_group_rule" "egress_to_graylog_rule" {
-  description              = "Allow egress to graylog hosts in engineering services VPC"
-  type                     = "egress"
-  from_port                = var.graylog_port
-  to_port                  = var.graylog_port
-  protocol                 = "tcp"
-  cidr_blocks              = var.graylog_cidr
-
-  security_group_id = aws_security_group.nsg_lb.id
-}
-

--- a/variables.tf
+++ b/variables.tf
@@ -76,16 +76,6 @@ variable "memory_alert_threshold" {
   default     = "80"
 }
 
-# Graylog Port
-variable "graylog_port" {
-  default = "12202"
-}
-
-# Graylog Cidr Block
-variable "graylog_cidr" {
-  description = "Cidr Block for Graylog"
-}
-
 variable "task_cpu" {
   default     = "256"
   description = "The number of cpu units to reserve for the task, must be higher than the all the CPU in the containers in the task"


### PR DESCRIPTION
There was an unnecessary security group rule for graylog, which is removed in this PR.