### PR TITLE
Load balancer allowed ingress IP ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | lb_port | The port the load balancer will listen on | string | `80` | no |
 | lb_protocol | The load balancer protocol | string | `HTTP` | no |
 | lb_internal | Whether the load balancer should be internal. | boolean | `false` | no |
+| lb_ingress_cidr_blocks | Ingress IP ranges that are allowed on the load balancer | string list | `["0.0.0.0/0"]` | no |
 | ecs_task_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the task is deployed into (should be private) | string | - | yes |
 | load_balancer_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the LB is deployed into (often public) | string | - | yes |
 | region | The AWS region to use for the dev environment's infrastructure Currently, Fargate is only available in `us-east-1`. | string | `us-east-1` | no |

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | lb_port | The port the load balancer will listen on | string | `80` | no |
 | lb_protocol | The load balancer protocol | string | `HTTP` | no |
 | lb_internal | Whether the load balancer should be internal. | boolean | `false` | no |
+| lb_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the LB is deployed into (often public) | string | - | yes |
 | lb_ingress_cidr_blocks | Ingress IP ranges that are allowed on the load balancer | string list | `["0.0.0.0/0"]` | no |
 | ecs_task_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the task is deployed into (should be private) | string | - | yes |
-| load_balancer_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the LB is deployed into (often public) | string | - | yes |
 | region | The AWS region to use for the dev environment's infrastructure Currently, Fargate is only available in `us-east-1`. | string | `us-east-1` | no |
 | replicas | How many containers to run | string | `1` | no |
 | tags | Tags for the infrastructure | map | - | yes |

--- a/lb-http.tf
+++ b/lb-http.tf
@@ -25,6 +25,6 @@ resource "aws_security_group_rule" "ingress_lb_http" {
   from_port         = var.http_port
   to_port           = var.http_port
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = var.lb_ingress_cidr_blocks
   security_group_id = aws_security_group.nsg_lb.id
 }

--- a/lb-https.tf
+++ b/lb-https.tf
@@ -26,6 +26,6 @@ resource "aws_security_group_rule" "ingress_lb_https" {
   from_port         = var.https_port
   to_port           = var.https_port
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = var.lb_ingress_cidr_blocks
   security_group_id = aws_security_group.nsg_lb.id
 }

--- a/lb.tf
+++ b/lb.tf
@@ -39,7 +39,7 @@ resource "aws_alb" "main" {
   name = "${var.app}-${var.environment}"
 
   # launch lbs in the public subnet
-  subnets         = split(",", var.load_balancer_subnets)
+  subnets         = split(",", var.lb_subnets)
   security_groups = [aws_security_group.nsg_lb.id]
   internal        = var.lb_internal
   tags            = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,11 @@ variable "ecs_task_subnets" {
 variable "load_balancer_subnets" {
 }
 
+# Ingress IP ranges that are allowed on the load balancer
+variable "lb_ingress_cidr_blocks" {
+  default = ["0.0.0.0/0"]
+}
+
 # The docker image that will be deployed to ECS
 variable "docker_image" {
   default = "nginx"

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "ecs_task_subnets" {
 }
 
 # The public subnets, minimum of 2, that are a part of the VPC(s)
-variable "load_balancer_subnets" {
+variable "lb_subnets" {
 }
 
 # Ingress IP ranges that are allowed on the load balancer


### PR DESCRIPTION
Breakdown:
- Make load balancer allowed ingress IP ranges configurable
- Unify lb variable naming: rename load_balancer_subnets to lb_subnets