### PR TITLE
EG-371 - SSM Fargate Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This module includes DataDog integration and requires a Datadog API key.
 
 This module creates a Fargate applicaiton with a CI/CD user, load balancer, alerts, dashboards and logs.
 
+This module supports using SSM secrets
+
 ## Examples
 
 See `/examples/`
@@ -21,6 +23,8 @@ See `/examples/`
 | container_port | The port the container will listen on, used for load balancer health check Best practice is that this value is higher than 1024 so the container processes isn't running at root. | string | - | yes |
 string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | datadog_api_key_from | The SSM pointer to the datadog api key | string | - | no |
+| kms_key_aliases | The Key aliases the app is allowed to decrypt with | list(string) | "alias/aws/ssm" | no |
+| secrets | The secrets SSM ARNs | list(name,valueFrom) | - | no |
 | deregistration_delay | The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused | string | `30` | no |
 | ecs_as_cpu_high_threshold_per | If the average CPU utilization over a minute rises to this threshold, the number of containers will be increased (but not above ecs_autoscale_max_instances). | string | `80` | no |
 | ecs_as_cpu_low_threshold_per | If the average CPU utilization over a minute drops to this threshold, the number of containers will be reduced (but not below ecs_autoscale_min_instances). | string | `20` | no |

--- a/ecs.tf
+++ b/ecs.tf
@@ -199,11 +199,26 @@ resource "aws_iam_role_policy" "secretsRead_policy" {
   policy = data.aws_iam_policy_document.secretsRead_policy_document.json
 }
 
+data "aws_kms_alias" "ssm_key" {
+  count = length(var.kms_key_aliases)
+  name = var.kms_key_aliases[count.index]
+}
+
 data "aws_iam_policy_document" "secretsRead_policy_document" {
   statement {
     actions = [
       "ssm:GetParameters",
     ]
-    resources = [var.datadog_api_key_from]
+    resources = concat([var.datadog_api_key_from], var.secrets[*].valueFrom)
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+      "kms:Decrypt"
+    ]
+    resources = [
+      data.aws_kms_alias.ssm_key[*].target_key_arn
+    ]
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -60,6 +60,7 @@ module "app_container_definition" {
   essential                = true
   readonly_root_filesystem = false
   environment              = var.environment_vars
+  secrets                  = "${var.secrets}"
   port_mappings = [
     {
       containerPort = var.container_port

--- a/ecs.tf
+++ b/ecs.tf
@@ -217,8 +217,6 @@ data "aws_iam_policy_document" "secretsRead_policy_document" {
       "kms:DescribeKey",
       "kms:Decrypt"
     ]
-    resources = [
-      data.aws_kms_alias.ssm_key[*].target_key_arn
-    ]
+    resources = data.aws_kms_alias.ssm_key[*].target_key_arn
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -60,7 +60,7 @@ module "app_container_definition" {
   essential                = true
   readonly_root_filesystem = false
   environment              = var.environment_vars
-  secrets                  = "${var.secrets}"
+  secrets                  = var.secrets
   port_mappings = [
     {
       containerPort = var.container_port

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,19 @@ variable "app" {
 variable "environment" {
 }
 
+# The secrets SSM ARNs
+variable "secrets" {
+  type = list(
+    object(
+      {
+        name = string
+        valueFrom = string
+      }
+    )
+  )
+  default = []
+}
+
 # The port the container will listen on, used for load balancer health check
 # Best practice is that this value is higher than 1024 so the container processes
 # isn't running at root.

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "app" {
 variable "environment" {
 }
 
+# Key aliases the app is allowed to decrypt with
+variable "kms_key_aliases" {
+  default = ["alias/aws/ssm"]
+  type = list(string)
+}
+
 # The secrets SSM ARNs
 variable "secrets" {
   type = list(


### PR DESCRIPTION
Added support for SSM parameter support for ECS

Allow SSM GetParameters to read datadog_api_key_from and secrets variable list.

New variable list can be used - kms_key_aliases, and will default to ["alias/aws/ssm"]

