### PR TITLE
Add optional variable to allow drop_invalid_header_fields to be enabled in the loadbalancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | lb_internal | Whether the load balancer should be internal. | boolean | `false` | no |
 | lb_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the LB is deployed into (often public) | string | - | yes |
 | lb_ingress_cidr_blocks | Ingress IP ranges that are allowed on the load balancer | string list | `["0.0.0.0/0"]` | no |
+| lb_drop_invalid_header_fields | Indicates whether invalid header fields are dropped in application load balancers. | boolean | false | no |
 | ecs_task_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the task is deployed into (should be private) | string | - | yes |
 | region | The AWS region to use for the dev environment's infrastructure Currently, Fargate is only available in `us-east-1`. | string | `us-east-1` | no |
 | replicas | How many containers to run | string | `1` | no |

--- a/lb.tf
+++ b/lb.tf
@@ -39,10 +39,11 @@ resource "aws_alb" "main" {
   name = "${var.app}-${var.environment}"
 
   # launch lbs in the public subnet
-  subnets         = split(",", var.lb_subnets)
-  security_groups = [aws_security_group.nsg_lb.id]
-  internal        = var.lb_internal
-  tags            = var.tags
+  subnets                    = split(",", var.lb_subnets)
+  security_groups            = [aws_security_group.nsg_lb.id]
+  internal                   = var.lb_internal
+  tags                       = var.tags
+  drop_invalid_header_fields = var.lb_drop_invalid_header_fields
 
   # enable access logs in order to get support from aws
   access_logs {

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,11 @@ variable "ecs_task_subnets" {
 variable "lb_subnets" {
 }
 
+# Whether to drop requests with invalid header fields to block desync attacks
+variable "lb_drop_invalid_header_fields" {
+  default = false
+}
+
 # Ingress IP ranges that are allowed on the load balancer
 variable "lb_ingress_cidr_blocks" {
   default = ["0.0.0.0/0"]


### PR DESCRIPTION
Ticket: https://ovotech.atlassian.net/browse/DSET-1035

Description:
Open up a new variable to allow drop_invalid_header_fields to be turned on in the application load balancer to help protect applications from desyncing attacks.

The load balancer documentation is here where this parameter is ultimately used: https://registry.terraform.io/modules/terraform-aws-modules/alb/aws/latest