### PR TITLE
Add ability to disallow task egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | lb_ingress_cidr_blocks | Ingress IP ranges that are allowed on the load balancer | string list | `["0.0.0.0/0"]` | no |
 | lb_drop_invalid_header_fields | Indicates whether invalid header fields are dropped in application load balancers. | boolean | false | no |
 | lb_logs_bucket_policy_override | A policy document to add to the load balancer logs bucket policy | string | `""` | no |
+| task_all_egress_allowed | Whether the task's security group allows all egress traffic or not | bool | true | no | 
 | ecs_task_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the task is deployed into (should be private) | string | - | yes |
 | region | The AWS region to use for the dev environment's infrastructure Currently, Fargate is only available in `us-east-1`. | string | `us-east-1` | no |
 | replicas | How many containers to run | string | `1` | no |

--- a/nsg.tf
+++ b/nsg.tf
@@ -40,6 +40,8 @@ resource "aws_security_group_rule" "nsg_task_ingress_rule" {
 }
 
 resource "aws_security_group_rule" "nsg_task_egress_rule" {
+  count = var.task_all_egress_allowed ? 1 : 0
+
   description = "Allows task to establish connections to all resources"
   type        = "egress"
   from_port   = "0"

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,11 @@ variable "lb_ingress_cidr_blocks" {
   default = ["0.0.0.0/0"]
 }
 
+# Whether to allow egress traffic from the task or not
+variable "task_all_egress_allowed" {
+  default = true
+}
+
 # The docker image that will be deployed to ECS
 variable "docker_image" {
   default = "nginx"


### PR DESCRIPTION
This PR adds a new variable to prevent adding the "allow all" egress rule to the task's security group. We require this so that we can selectively add egress rules to the security group.

I have defaulted it to `true` to maintain backwards compatibility.