### PR TITLE
Add optional load balancer ssl_policy for HTTPS listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | lb_ingress_cidr_blocks | Ingress IP ranges that are allowed on the load balancer | string list | `["0.0.0.0/0"]` | no |
 | lb_drop_invalid_header_fields | Indicates whether invalid header fields are dropped in application load balancers. | boolean | false | no |
 | lb_logs_bucket_policy_override | A policy document to add to the load balancer logs bucket policy | string | `""` | no |
+| lb_tls_policy | The [security policy](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) to use for the HTTPS load balancer's SSL configuration | string | `"ELBSecurityPolicy-2016-08"` | no |
 | task_all_egress_allowed | Whether the task's security group allows all egress traffic or not | bool | true | no | 
 | ecs_task_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the task is deployed into (should be private) | string | - | yes |
 | region | The AWS region to use for the dev environment's infrastructure Currently, Fargate is only available in `us-east-1`. | string | `us-east-1` | no |

--- a/lb-https.tf
+++ b/lb-https.tf
@@ -8,11 +8,16 @@ variable "https_port" {
 
 variable "certificate_arn" {}
 
+variable "lb_tls_policy" {
+  default = "ELBSecurityPolicy-2016-08"
+}
+
 resource "aws_alb_listener" "https" {
   load_balancer_arn = aws_alb.main[0].id
   port              = var.https_port
   protocol          = "HTTPS"
   certificate_arn   = var.certificate_arn
+  ssl_policy        = var.lb_tls_policy
 
   default_action {
     target_group_arn = aws_alb_target_group.main.id


### PR DESCRIPTION
This PR makes the `ssl_policy` parameter of the HTTPS listener configurable. It was identified during a security audit that the default value `ELBSecurityPolicy-2016-08` makes use of TLSv1.0 which is considered insecure. Note that I am not changing the default to maintain backwards compatibility.