### PR TITLE
EG-1686 Add option to disable the HTTP redirect on the load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | lb_drop_invalid_header_fields | Indicates whether invalid header fields are dropped in application load balancers. | boolean | false | no |
 | lb_logs_bucket_policy_override | A policy document to add to the load balancer logs bucket policy | string | `""` | no |
 | lb_tls_policy | The [security policy](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) to use for the HTTPS load balancer's SSL configuration | string | `"ELBSecurityPolicy-2016-08"` | no |
+| lb_http_redirect | Whether to redirect from HTTP to HTTPS or not. | boolean | `true` | no |
 | task_all_egress_allowed | Whether the task's security group allows all egress traffic or not | bool | true | no | 
 | ecs_task_subnets | The subnets, minimum of 2, that are a part of the VPC(s), that the task is deployed into (should be private) | string | - | yes |
 | region | The AWS region to use for the dev environment's infrastructure Currently, Fargate is only available in `us-east-1`. | string | `us-east-1` | no |

--- a/lb-http.tf
+++ b/lb-http.tf
@@ -3,7 +3,13 @@ variable "http_port" {
   default = "80"
 }
 
+variable "lb_http_redirect" {
+  default = true
+}
+
 resource "aws_alb_listener" "redirect_http_to_https" {
+  count = var.lb_http_redirect ? 1 : 0
+
   load_balancer_arn = aws_alb.main[0].id
   port              = var.http_port
   protocol          = "HTTP"
@@ -20,6 +26,8 @@ resource "aws_alb_listener" "redirect_http_to_https" {
 }
 
 resource "aws_security_group_rule" "ingress_lb_http" {
+  count = var.lb_http_redirect ? 1 : 0
+
   type              = "ingress"
   description       = "HTTP"
   from_port         = var.http_port


### PR DESCRIPTION
This PR adds an option to the module to disable the HTTP redirect on the load balancer. This was found to be a potential security vulnerability in our recent security audit, and as our team does not rely on the behaviour at all we need a way of disabling it. I am leaving the default with the functionality still enabled in order to be backwards compatible.