### PR TITLE
Added container insights flag to ECS cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | additional_user_groups | Any additional groups the user should belong to that's used for deploying your fargate app. | list(string) | [] | no |
 | enable_datadog_log_forwarding| Should enable data dog log forwarding. datadog_api_key_from must also be set for this to be enabled. You may need to modify task_memory, task_cpu, container_memory, container_cpu to account for this new container being added. | bool | false | no
 | HTTPCode_ELB_5XX_threshold | Threshold for ELB 5XX alert | string | 25 | no
+| ecs_container_insights | Whether to enable CloudWatch Container Insights on the Fargate cluster | boolean | `false` | no 
 ## Outputs
 
 | Name | Description |

--- a/ecs.tf
+++ b/ecs.tf
@@ -90,7 +90,7 @@ locals {
   # use cloudwatch container insights if containerInsights is enabled
   container_insights_setting = {
     name  = "containerInsights"
-    value = var.containerInsights
+    value = var.containerInsights ? "enabled" : "disabled"
   }
 
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -90,7 +90,7 @@ locals {
   # use cloudwatch container insights if containerInsights is enabled
   container_insights_setting = {
     name  = "containerInsights"
-    value = var.containerInsights ? "enabled" : "disabled"
+    value = var.ecs_container_insights ? "enabled" : "disabled"
   }
 
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -86,11 +86,19 @@ locals {
 
   # merge and flatten decisions
   container_defs = flatten(concat(local.app_container,  local.firelens_dd_app_container))
+
+  # use cloudwatch container insights if containerInsights is enabled
+  container_insights_setting = {
+    name  = "containerInsights"
+    value = var.containerInsights
+  }
+
 }
 
 resource "aws_ecs_cluster" "app" {
   name = "${var.app}-${var.environment}"
   tags = var.tags
+  setting = local.container_insights_setting
 }
 
 resource "aws_appautoscaling_target" "app_scale_target" {

--- a/variables.tf
+++ b/variables.tf
@@ -164,3 +164,8 @@ variable "HTTPCode_ELB_5XX_threshold" {
   description = "Threshold for ELB 5XX alert"
   default     = "25"
 }
+
+variable "ecs_container_insights" {
+  description = "Set to enable CloudWatch Container Insights for a Fargate cluster."
+  default     = false
+}


### PR DESCRIPTION
This PR adds an option to the module to enable CloudWatch Container Insights on the ECS cluster. This was required to provide additional metrics at cluster, task and service levels